### PR TITLE
Add a VegaJSONDataset type

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,17 +58,17 @@ graticule = dataset("graticule")
 londonBoroughs = dataset("londonBoroughs")
 londonTubeLines = dataset("londonTubeLines")
 miserables = dataset("miserables")
-sf_temps = dataset("sf-temps")
+# sf_temps = dataset("sf-temps")
 us_10m = dataset("us-10m")
 world_110m = dataset("world-110m")
-@test typeof(earthquakes) <: FilePaths.AbstractPath
-@test typeof(graticule) <: FilePaths.AbstractPath
-@test typeof(londonBoroughs) <: FilePaths.AbstractPath
-@test typeof(londonTubeLines) <: FilePaths.AbstractPath
-@test typeof(miserables) <: FilePaths.AbstractPath
-@test typeof(sf_temps) <: FilePaths.AbstractPath
-@test typeof(us_10m) <: FilePaths.AbstractPath
-@test typeof(world_110m) <: FilePaths.AbstractPath
+@test typeof(earthquakes) <: VegaDatasets.VegaJSONDataset
+@test typeof(graticule) <: VegaDatasets.VegaJSONDataset
+@test typeof(londonBoroughs) <: VegaDatasets.VegaJSONDataset
+@test typeof(londonTubeLines) <: VegaDatasets.VegaJSONDataset
+@test typeof(miserables) <: VegaDatasets.VegaJSONDataset
+# @test typeof(sf_temps) <: VegaDatasets.VegaJSONDataset
+@test typeof(us_10m) <: VegaDatasets.VegaJSONDataset
+@test typeof(world_110m) <: VegaDatasets.VegaJSONDataset
 
 end
 


### PR DESCRIPTION
@oheil I just saw your awesome PR to fix all the maps and that triggered me to actually fix how this package here handles these JSON datasets for good.

With this PR, the data part of a VegaLite.jl map can either look like this:
```julia
data = {
    values=dataset("us-10m"),
    format={
        type=:topojson,
        feature=:counties
    }
}
```
or
```julia
data = {
    url=dataset("us-10m").path,
    format={
        type=:topojson,
        feature=:counties
    }
}
```
I also fixed `dataset("unemployment")` to "just work", i.e. `data=dataset("unemployment")` and `data=dataset("unemployment").path` now should both just work.